### PR TITLE
Update Werkzeug to 0.10.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ Markdown==2.4
 MarkupSafe==0.19
 SQLAlchemy==0.9.3
 WTForms==1.0.5
-Werkzeug==0.9.4
+Werkzeug==0.10.4
 bleach==1.4
 blinker==1.3
 coverage==3.7.1


### PR DESCRIPTION
Update Werkzeug to 0.10.4 to fix "TypeError: 'unicode' does not have the buffer interface" error