### PR TITLE
Convert flask.ext. to flask_ to quiet the warnings.

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,10 +1,10 @@
 from flask import Flask
-from flask.ext.bootstrap import Bootstrap
-from flask.ext.sqlalchemy import SQLAlchemy
-from flask.ext.login import LoginManager
-from flask.ext.moment import Moment
-from flask.ext.pagedown import PageDown
-from flask.ext.mail import Mail
+from flask_bootstrap import Bootstrap
+from flask_sqlalchemy import SQLAlchemy
+from flask_login import LoginManager
+from flask_moment import Moment
+from flask_pagedown import PageDown
+from flask_mail import Mail
 from config import config
 
 bootstrap = Bootstrap()

--- a/app/auth/forms.py
+++ b/app/auth/forms.py
@@ -1,4 +1,4 @@
-from flask.ext.wtf import Form
+from flask_wtf import Form
 from wtforms import StringField, PasswordField, BooleanField, SubmitField
 from wtforms.validators import Required, Length, Email
 

--- a/app/auth/routes.py
+++ b/app/auth/routes.py
@@ -1,6 +1,6 @@
 from flask import render_template, current_app, request, redirect, url_for, \
     flash
-from flask.ext.login import login_user, logout_user, login_required
+from flask_login import login_user, logout_user, login_required
 from ..models import User
 from . import auth
 from .forms import LoginForm

--- a/app/emails.py
+++ b/app/emails.py
@@ -2,7 +2,7 @@ from threading import Thread
 import time
 from datetime import datetime
 from flask import current_app, render_template, url_for
-from flask.ext.mail import Message
+from flask_mail import Message
 from . import db
 from .models import PendingEmail
 from . import mail

--- a/app/models.py
+++ b/app/models.py
@@ -5,7 +5,7 @@ import bleach
 from werkzeug.security import generate_password_hash, check_password_hash
 from itsdangerous import TimedJSONWebSignatureSerializer as Serializer
 from flask import request, current_app
-from flask.ext.login import UserMixin
+from flask_login import UserMixin
 from . import db, login_manager
 
 

--- a/app/talks/forms.py
+++ b/app/talks/forms.py
@@ -1,8 +1,8 @@
-from flask.ext.wtf import Form
+from flask_wtf import Form
 from wtforms import StringField, TextAreaField, BooleanField, SubmitField
 from wtforms.fields.html5 import DateField
 from wtforms.validators import Optional, Length, Required, URL, Email
-from flask.ext.pagedown.fields import PageDownField
+from flask_pagedown.fields import PageDownField
 
 
 class ProfileForm(Form):

--- a/app/talks/routes.py
+++ b/app/talks/routes.py
@@ -1,6 +1,6 @@
 from flask import render_template, flash, redirect, url_for, abort,\
     request, current_app
-from flask.ext.login import login_required, current_user
+from flask_login import login_required, current_user
 from .. import db
 from ..models import User, Talk, Comment, PendingEmail
 from ..emails import send_author_notification, send_comment_notification

--- a/manage.py
+++ b/manage.py
@@ -8,7 +8,7 @@ if os.path.exists('.env'):
             os.environ[var[0]] = var[1]
 
 from app import create_app
-from flask.ext.script import Manager
+from flask_script import Manager
 from app import db
 from app.models import User
 


### PR DESCRIPTION
Replace all occurences of flask.ext.modulename with flask_modulename to silence the warnings and bring the code up to date since flask.ext.modulename is deprecated.
